### PR TITLE
fix：根治空表格返回undefined的问题

### DIFF
--- a/core/table/base.js
+++ b/core/table/base.js
@@ -215,9 +215,7 @@ export class SheetBase {
      * @returns
      */
     getSheetCSV( removeHeader = true,key = 'value') {
-        if (this.isEmpty())
-            if (this.required) return this.source.initNode;
-            else return '';
+        if (this.isEmpty()) return ''; //根治表格为空时出现undefined的问题
         console.log("测试获取map", this.cells)
         const content = this.hashSheet.slice(removeHeader?1:0).map((row, index) => row.map(cellUid => {
             const cell = this.cells.get(cellUid)


### PR DESCRIPTION
获取CVS格式内容时表格为空时无需返回initNode，因为已在另外一个函数实现，此处重复了，还会导致获取rows时。返回undefined的问题