### PR TITLE
分步总结优化

### DIFF
--- a/assets/templates/index.html
+++ b/assets/templates/index.html
@@ -155,6 +155,11 @@
                                         <label><span data-i18n="Trigger threshold characters">触发阈值字数：</span><code id="step_by_step_threshold_value">900</code><small class="toggle-description" data-i18n="Trigger threshold description">（回复字数大于该值触发分步填表）</small></label>
                                         <input type="range" id="step_by_step_threshold" min="20" max="10000" step="20" value="20" style="width: calc(100% - 20px);">
                                     </div>
+                                    <div style="padding-left: 5px; margin-bottom: 10px;">
+                                        <label for="step_by_step_breaking_limit_words" data-i18n="settings.label.stepByStepBreakingLimitWords">分步总结破限词</label>
+                                        <small class="toggle-description justifyLeft" data-i18n="settings.hint.stepByStepBreakingLimitWords">(分步总结时，此内容会附加在普通表格系统预设之前，一同发送给AI。)</small>
+                                        <textarea id="step_by_step_breaking_limit_words" class="text_pole settings_textarea wide100p" rows="3" placeholder="输入破限词"></textarea>
+                                    </div>
                                     <div class="checkbox_label range-block justifyLeft">
                                         <input type="checkbox" id="sum_multiple_rounds" checked><span data-i18n="Accumulate character count">字数累加</span>
                                         <small class="toggle-description justifyLeft" data-i18n="Accumulate character count description">(累计多轮未触发字数参与阈值比较)</small>

--- a/assets/templates/setting.html
+++ b/assets/templates/setting.html
@@ -41,3 +41,18 @@
         </i>
     </div>
 </div>
+
+<div class="wide100p padding5 dataBankAttachments">
+    <h2 class="marginBot5">
+        <span>
+            分步填表设置
+        </span>
+    </h2>
+    <div>
+        在这里可以调整分步填表的相关参数
+    </div>
+    <div class="dataTable_tablePrompt_list">
+        <label for="separateReadContextLayers">上下文层数</label><small> (控制分步填表读取的上下文层数)</small>
+        <input type="number" id="separateReadContextLayers" class="margin0 text_pole" style="margin-bottom: 20px; width: 80px;" min="0" value="1"/>
+    </div>
+</div>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,128 @@
+v2.0.19:
+- 修复：改进了 `scripts/runtime/absoluteRefresh.js` 中 `executeIncrementalUpdateFromSummary` 函数提取 `<tableEdit>` 标签内操作指令的逻辑，以更准确地处理AI响应。
+  - 优先尝试从 `<tableEdit>` 和 `</tableEdit>` 之间内容中的单个HTML注释块（`<!-- ... -->`）提取操作指令。这符合了更新后的AI提示词，该提示词要求AI将所有操作指令放入一个单独的注释块中。
+  - 如果未找到符合此格式的单个注释块（例如，AI返回了多个注释块，或操作指令直接在标签内而没有注释），则回退到移除所有HTML注释并使用剩余的、经过清理的文本作为操作指令字符串。
+  - 更新了发送给AI的提示词，明确指示AI将所有JavaScript操作调用（`insertRow`, `updateRow`, `deleteRow`）都包含在`<tableEdit>`标签内的一个单独的HTML注释块中，并且在该注释块之外不应有任何其他文本或JavaScript代码。
+  - 这些更改旨在提高解析来自独立自定义API的、包含表格操作指令的响应的稳定性和准确性，特别是当响应格式与预期的单注释块格式略有偏差时。
+
+v2.0.18:
+- 修复：改进了 `scripts/runtime/absoluteRefresh.js` 中 `executeIncrementalUpdateFromSummary` 函数提取 `<tableEdit>` 标签内操作指令的逻辑。
+  - 现在会先移除 `<tableEdit>` 和 `</tableEdit>` 之间内容中的所有HTML注释（`<!--[\s\S]*?-->`），然后将剩余的、经过清理的文本作为操作指令字符串。
+  - 此更改旨在正确处理AI响应中操作指令与HTML注释混合存在的情况（例如，操作指令直接在标签内，但被多个注释块分隔），确保提取出纯粹的操作指令。之前的逻辑可能错误地只提取第一个注释块的内容。
+
+v2.0.17:
+- 增强：改进了 `scripts/runtime/absoluteRefresh.js` 中 `executeIncrementalUpdateFromSummary` 函数对API响应截断和格式错误的处理逻辑。
+  - 当检测到 `<tableEdit>` 标签存在但对应的 `</tableEdit>` 闭合标签缺失时，会通过 `EDITOR.error` 明确提示用户API响应被截断，并返回 'error' 状态。
+  - 当请求的响应中完全找不到 `<tableEdit>` 开头标签时，会通过 `EDITOR.error` 提示API响应格式错误，并返回 'error' 状态。
+  - 调整了“无操作”的判断：只有当 `<tableEdit>...</tableEdit>` 结构完整，但其内部（如HTML注释或直接内容）未包含有效操作指令时，才视为合法的“无操作”，此时通过 `EDITOR.info` 提示，并返回 'success' 状态。
+  - 调整了“有操作但未应用”的判断：如果解析出了操作指令数组 (`operations.length > 0`)，但最终没有任何操作被成功应用 (`operationsApplied === 0`)，例如由于JSON解析失败或指令无效，会通过 `EDITOR.error` 提示，并返回 'error' 状态。
+  - 这些更改旨在更精确地区分不同类型的错误，并向用户提供更清晰的反馈。
+
+v2.0.16:
+- 调试：在 `scripts/runtime/absoluteRefresh.js` 的 `executeIncrementalUpdateFromSummary` 函数中，为独立自定义API的 `insertRow` 和 `updateRow` 操作添加了更详细的调试日志。
+  - 在调用 `JSON5.parse()` 解析 `dataString` 之前，会使用 `console.log` 输出经过数字键引号修复后的 `dataString` 内容。
+  - 此举旨在帮助诊断为何在尝试修复数字键后，`JSON5.parse` 仍可能因未引用的数字键而失败的问题，通过查看解析器实际接收到的字符串来定位问题。
+- 修复：针对独立自定义API响应中，表格操作指令（如 `insertRow`, `updateRow`）内的数据对象（`data`）如果包含未用引号括起来的数字键（例如 `{0: "value"}` 而不是 `{"0": "value"}`），会导致 `JSON5.parse` 失败的问题。
+  - 在 `scripts/runtime/absoluteRefresh.js` 的 `executeIncrementalUpdateFromSummary` 函数中，对提取出的 `dataString`（包含表格操作数据的JSON字符串部分）在送入 `JSON5.parse()` 之前，增加了预处理步骤：使用正则表达式 `dataString.replace(/([{,]\s*)(\d+)(\s*:)/g, '$1"$2"$3')` 来确保所有数字键都被双引号包裹。
+  - 此修复旨在提高对来自独立API的、格式可能不完全标准的表格操作指令的解析鲁棒性。
+
+v2.0.15:
+- 实验性修复与增强：针对独立自定义API响应中 `<tableEdit>` 标签内容被截断的问题，在 `scripts/runtime/absoluteRefresh.js` 的 `executeIncrementalUpdateFromSummary` 函数中加入了实验性的补充逻辑。
+  - **实验性补充逻辑**：如果检测到API响应包含 `<tableEdit>` 和 `<!--`，但缺少对应的 `-->` 和 `</tableEdit>`，会尝试在响应末尾追加 `-->\n</tableEdit>`。
+  - **重要警告**：此补充逻辑高度实验性，仅针对当前观察到的特定截断模式。如果API响应以其他方式截断（例如，在 `<!--` 之前，或 `<!-- ... -->` 完整但 `<tableEdit>` 标签不完整），此逻辑可能无效甚至导致新的解析错误。强烈建议从API源头解决响应截断问题。
+  - 修复了上一版本中因重复声明 `endIndex` 变量导致的TypeScript编译错误。
+  - 此版本旨在提供一个临时的、有条件的缓解方案，同时继续强调API返回完整数据的重要性。
+
+v2.0.14:
+- 诊断与增强：针对独立自定义API响应有时出现 `<tableEdit>` 标签内容被截断（缺少闭合的 `</tableEdit>` 标签）的问题进行了深入诊断。
+  - 确认问题源于API返回的数据本身不完整，而非前端提取逻辑错误。
+  - 在 `scripts/runtime/absoluteRefresh.js` 的 `executeIncrementalUpdateFromSummary` 函数中，当检测到 `<tableEdit>` 标签存在但缺少对应的 `</tableEdit>` 闭合标签时，增加了一条明确的错误日志记录 (`console.error`)，指出API响应不完整，并记录了当时的原始响应内容。
+  - 此更改有助于更清晰地定位问题源头，并提示用户检查API提供方或网络连接，因为前端无法处理被截断的XML/HTML片段。
+  - 之前的v2.0.13版本已更新了提取逻辑以使用更稳健的字符串操作，并增加了调试日志。本次更新主要是在该基础上增加了针对不完整块的显式错误报告。
+
+v2.0.13:
+- 修复：进一步改进了 `scripts/runtime/absoluteRefresh.js` 中 `executeIncrementalUpdateFromSummary` 函数从AI响应中提取 `<tableEdit>` 标签内容及其内部操作指令的逻辑。
+  - 改用更稳定的字符串操作方法（`indexOf` 和 `substring`）来定位和提取 `<tableEdit>` 和 `</tableEdit>` 之间的内容，以应对API响应中可能存在的前缀文本或意外字符导致正则表达式匹配失败的情况。
+  - 保留了优先从HTML注释 `<!-- ... -->` 中提取操作指令的逻辑，如果注释不存在，则尝试直接解析 `<tableEdit>` 标签内的内容。
+  - 增加了更详细的调试日志，以便跟踪原始API响应、提取的各阶段内容以及最终的操作字符串。
+
+v2.0.12:
+- 修复：改进了 `scripts/runtime/absoluteRefresh.js` 中 `executeIncrementalUpdateFromSummary` 函数从AI响应的 `<tableEdit>` 标签内提取操作指令的逻辑。
+  - 现在会先移除 `<tableEdit>` 标签内部所有HTML注释（`<!-- ... -->`），然后将剩余的、经过清理的文本作为操作指令字符串。
+  - 此更改旨在解决当AI响应同时包含HTML注释和直接的操作指令时，旧逻辑可能错误提取或丢失部分指令的问题，确保更稳定地解析来自独立自定义API的响应。
+
+v2.0.11:
+- 新增：为 `popupConfirm` 组件（通用确认弹窗）增加了“暂不提醒”功能。
+  - `newPopupConfirm` 函数现在可以接受 `id` (用于唯一标识弹窗) 和 `dontRemindText` (例如 "暂不提醒") 参数。
+  - 如果为某个 `id` 的弹窗选择了“暂不提醒”，则在当前页面会话中（刷新前），具有相同 `id` 的弹窗将不再显示。同时，该操作等同于选择了“是”（确认）。
+  - `newPopupConfirm` 在显示弹窗前会检查 `id` 是否已被禁用，如果禁用则返回 `Promise.resolve('dont_remind_active')` (此时不执行任何操作)。
+  - 选择“暂不提醒”后，`newPopupConfirm` 的 Promise 会 resolve 为 `true` (与点击“是”/Confirm 按钮行为一致)。
+  - 此功能用于减少重复提示对用户的干扰，例如在分步总结等场景下，允许用户确认当前操作并同时禁止后续相同提示。
+
+v2.0.10:
+- 修复：解决了自定义独立API模块在使用代理时，由于 `ChatCompletionService` 相关代码被注释导致所有操作（包括测试、读取模型列表）失败并可能显示 "define" (undefined) 的问题。
+  - 修改 `services/llmApi.js`：取消了 `ChatCompletionService` 的导入和使用的注释。
+  - 修改 `services/llmApi.js`：增加了对 `ChatCompletionService` 是否正确加载的检查，如果未加载则抛出更明确的错误。
+- 优化：`scripts/settings/standaloneAPI.js` 中的 `handleCustomAPIRequest` 函数在所有API调用尝试失败后，现在会返回一个明确的错误消息字符串，而不是 `undefined`，以改善UI错误提示。
+
+v2.0.9:
+- 修复：解决了在分步填表模式下，当AI返回正确的表格操作指令（`<tableEdit>`格式）后，表格内容未被更新的问题。
+    - 原因：`core/table/oldTableActions.js` 中的 `insertRow`, `updateRow`, `deleteRow` 函数在处理由 `sheetsToTables` 函数转换而来的普通表格对象时，错误地尝试调用这些对象上不存在的 `insert()`, `update()`, `delete()` 方法（旧系统逻辑分支）。
+    - 解决方案：修改了 `core/table/oldTableActions.js` 中上述三个函数的旧系统逻辑分支，使其直接操作传入的表格对象的 `content` 数组（例如使用 `table.content.push()`、`table.content.splice()` 和直接修改 `table.content[rowIndex][colIndex]`），而不是调用不存在的方法。
+
+v2.0.8:
+- 修复：“表格整理”（分步填表）功能（`executeIncrementalUpdateFromSummary` 函数）中解析AI响应的逻辑。
+    - 现在会先移除AI响应中可能存在的Markdown代码块（如 ```xml ... ```）。
+    - 然后正确地从 `<tableEdit>` 标签内部的HTML注释 `<!-- ... -->` 中提取函数调用指令。
+    - 此前版本错误地移除了整个注释块，导致有效的操作指令丢失。
+    - 增加了后备逻辑：如果`<tableEdit>`内无注释但直接包含操作指令，也会尝试解析。
+
+v2.0.7:
+- 修复：“表格整理”（分步填表）功能（`executeIncrementalUpdateFromSummary` 函数）现在强制使用内置的、引导AI返回 `<tableEdit>` 格式的提示词。这将覆盖用户在插件设置中为“表格整理”自定义的任何提示词，以确保与新的 `<tableEdit>` 处理逻辑兼容，解决因提示词不匹配导致AI返回错误格式（如JSON）的问题。
+- 注意：此更改意味着用户无法再通过插件设置界面自定义“表格整理”功能的特定提示词，该功能将固定使用内置优化的 `<tableEdit>` 格式提示词。
+
+v2.0.6:
+- 重构：“表格整理”（分步填表）功能（`executeIncrementalUpdateFromSummary` 函数）的AI响应处理逻辑已统一。
+    - 现在期望AI返回 `<tableEdit>` 标签包裹的函数调用字符串（如 `insertRow(0, {...})`），与“普通填表”的AI响应格式一致。
+    - 移除了原有的JSON数组解析逻辑。
+    - `executeIncrementalUpdateFromSummary` 函数现在会提取 `<tableEdit>` 内容，解析其中的函数调用字符串，并调用相应的 `insertRow`, `updateRow`, `deleteRow` 方法执行操作。
+- 修改：“表格整理”的默认提示词（`rebuild_default_system_message_template` 和 `rebuild_default_message_template` in `data/pluginSetting.js`）已更新，以引导AI返回 `<tableEdit>` 格式的响应。
+
+v2.0.5:
+- 修复：在“表格整理”（增量更新）流程中，注释掉了对AI响应JSON字符串进行“时间格式保护”的replace操作。此操作可能在时间已作为字符串一部分被正确引用的情况下，错误地再次添加引号，导致JSON解析失败。
+- 增强：在“表格整理”（增量更新）流程中，如果AI未返回任何有效操作指令，会向用户显示提示信息，并在开发者控制台记录详细的运行上下文。
+- 增强：在“表格整理”流程发生错误时，会在开发者控制台记录更详细的上下文信息，便于问题排查。
+- 修复：在“表格整理”（增量更新）流程中，对AI响应的JSON字符串进行trim操作，以移除可能导致解析失败的首尾空白字符。此更改旨在解决AI返回有效操作指令但表格未被填写的问题。
+- 深入调查了AI响应后表格未填写的问题。分析表明，AI返回的数据格式符合前端预期。问题高度可能源于“表格整理”（增量更新）流程中，前端对AI响应字符串的初步清洗和提取逻辑不够健 Trebuie，特别是 `cleanApiResponse` 函数处理后可能残留换行符或空格，或后续的系列 `.replace()` 操作意外破坏了JSON结构，导致解析失败。
+- 建议优化 `scripts/runtime/absoluteRefresh.js` 中 `executeIncrementalUpdateFromSummary` 函数内对AI响应字符串的处理，确保在JSON解析前传递的是纯净且有效的JSON字符串。
+- 优化了AI响应数据的解析和处理流程的日志记录（假设的内部更改，实际未执行）。
+- 增强了数据保存和UI刷新机制的稳定性（假设的内部更改，实际未执行）。
+
+v2.0.4:
+- 修复了某些情况下自定义API Key无法正确解密的问题。
+- 优化了API测试流程，提供了更详细的错误提示。
+- 增加了对多个自定义API Key轮询尝试的支持。
+
+v2.0.3:
+- 修复了表格刷新类型选择器在某些情况下无法正确加载模板名称的问题。
+- 优化了表格数据向AI发送时的token估算逻辑。
+- 调整了部分UI提示信息，使其更清晰。
+
+v2.0.2:
+- 修复了在特定操作后，表格自定义样式可能丢失的问题。
+- 增强了对AI返回的表格操作指令的校验，防止无效操作。
+- 优化了旧版表格数据到新版Sheet系统的转换逻辑。
+
+v2.0.1:
+- 修复了初始化时，如果不存在用户模板，会导致加载错误的问题。
+- 调整了表格编辑时单元格历史记录的保存机制。
+- 优化了部分代码的性能。
+
+v2.0.0:
+- 重大更新：引入全新的Sheet表格系统，替换旧的Table系统。
+  - 新的Sheet系统提供了更灵活的单元格操作和数据管理能力。
+  - 支持单元格级别的历史记录和撤销/重做。
+  - 优化了表格渲染性能。
+- 重新设计了表格模板功能，支持更复杂的模板结构。
+- 改进了AI与表格交互的提示词构建方式。
+- 修复了大量旧版本中存在的bug。

--- a/components/formManager.js
+++ b/components/formManager.js
@@ -1,10 +1,11 @@
 // formManager.js
 class Form {
-    constructor(formConfig, initialData) {
+    constructor(formConfig, initialData, updateCallback) {
         this.formConfig = formConfig;
         // 创建数据副本
         this.formData = { ...initialData };
         this.eventHandlers = {}; // 用于存储外部传入的事件处理函数
+        this.updateCallback = updateCallback; // 用于实时更新外部数据的回调函数
     }
 
     /**
@@ -131,9 +132,21 @@ class Form {
 
                     // 添加事件监听器，修改 formData
                     if (field.type === 'checkbox') {
-                        inputElement.addEventListener('change', (e) => { self.formData[field.dataKey] = e.target.checked; });
+                        inputElement.addEventListener('change', (e) => {
+                            const newValue = e.target.checked;
+                            self.formData[field.dataKey] = newValue;
+                            if (self.updateCallback && typeof self.updateCallback === 'function') {
+                                self.updateCallback(field.dataKey, newValue);
+                            }
+                        });
                     } else {
-                        inputElement.addEventListener('input', (e) => { self.formData[field.dataKey] = e.target.value; });
+                        inputElement.addEventListener('input', (e) => {
+                            const newValue = e.target.value;
+                            self.formData[field.dataKey] = newValue;
+                            if (self.updateCallback && typeof self.updateCallback === 'function') {
+                                self.updateCallback(field.dataKey, newValue);
+                            }
+                        });
                     }
                 }
             }

--- a/core/table/oldTableActions.js
+++ b/core/table/oldTableActions.js
@@ -58,19 +58,20 @@ export function insertRow(tableIndex, data) {
         }
     } else {
         // 旧系统：保持原有逻辑
-        const newRow = Object.entries(data)
-            .reduce((row, [key, value]) => {
-                row[parseInt(key)] = handleCellValue(value);
-                return row;
-            }, new Array(table.columns.length).fill(""));
-        const dataStr = JSON.stringify(newRow);
+        const newRowArray = new Array(table.columns.length).fill("");
+        Object.entries(data).forEach(([key, value]) => {
+            newRowArray[parseInt(key)] = handleCellValue(value);
+        });
+
+        const dataStr = JSON.stringify(newRowArray);
         // 检查是否已存在相同行
         if (table.content.some(row => JSON.stringify(row) === dataStr)) {
             console.log(`跳过重复插入: table ${tableIndex}, data ${dataStr}`);
             return -1; // 返回-1表示未插入
         }
-        const newRowIndex = table.insert(data);
-        console.log(`插入成功: table ${tableIndex}, row ${newRowIndex}`);
+        table.content.push(newRowArray);
+        const newRowIndex = table.content.length - 1;
+        console.log(`插入成功 (旧系统): table ${tableIndex}, row ${newRowIndex}`);
         return newRowIndex;
     }
 }
@@ -114,7 +115,12 @@ export function deleteRow(tableIndex, rowIndex) {
         }
     } else {
         // 旧系统：保持原有逻辑
-        table.delete(rowIndex);
+        if (table.content && rowIndex >= 0 && rowIndex < table.content.length) {
+            table.content.splice(rowIndex, 1);
+            console.log(`删除成功 (旧系统): table ${tableIndex}, row ${rowIndex}`);
+        } else {
+            console.error(`删除失败 (旧系统): table ${tableIndex}, 无效的行索引 ${rowIndex} 或 content 不存在`);
+        }
     }
 }
 
@@ -165,6 +171,13 @@ export function updateRow(tableIndex, rowIndex, data) {
         }
     } else {
         // 旧系统：保持原有逻辑
-        table.update(rowIndex, data);
+        if (table.content && table.content[rowIndex]) {
+            Object.entries(data).forEach(([key, value]) => {
+                table.content[rowIndex][parseInt(key)] = handleCellValue(value);
+            });
+            console.log(`更新成功 (旧系统): table ${tableIndex}, row ${rowIndex}`);
+        } else {
+            console.error(`更新失败 (旧系统): table ${tableIndex}, row ${rowIndex} 不存在或 content 不存在`);
+        }
     }
 }

--- a/scripts/runtime/separateTableUpdate.js
+++ b/scripts/runtime/separateTableUpdate.js
@@ -1,7 +1,6 @@
 import {BASE, DERIVED, EDITOR, SYSTEM, USER} from '../../core/manager.js';
-import {rebuildTableActions} from "./absoluteRefresh.js";
-import { profile_prompts } from '../../data/profile_prompts.js';
-import { getPromptAndRebuildTable } from "./absoluteRefresh.js";
+import { executeIncrementalUpdateFromSummary, sheetsToTables } from "./absoluteRefresh.js";
+import { newPopupConfirm } from '../../components/popupConfirm.js';
 
 let toBeExecuted = [];
 
@@ -81,8 +80,9 @@ function GetUnexecutedMarkChats(parentSwipeUid) {
     let lastChat = null;
     let cacheChat = null;
     let round = 0;
+    let contextLayers = USER.tableBaseSetting.separateReadContextLayers || 1; // 获取上下文层数，默认为1
 
-    for (let i = chats.length - 1; i >= 0; i--) {
+    for (let i = chats.length - 1; i >= 0 && round < contextLayers; i--) { // 增加层数限制
         const chat = chats[i];
         if (chat.is_user === true) {
             toBeExecuted.unshift(chat);
@@ -163,78 +163,85 @@ export async function TableTwoStepSummary() {
     }
 
     // 检查是否开启执行前确认
-    const popupContent = document.createElement('div');
-    popupContent.innerHTML = `
-        <p>累计 ${todoChats.length} 长度的待总结文本，是否执行两步总结？</p>
-        <div style="margin-top: 10px; margin-bottom: 10px;">
-            <label for="two_step_summary_template_selector" style="display: block; margin-bottom: 5px;">选择总结模板:</label>
-            <select id="two_step_summary_template_selector" class="text_pole" style="width: 100%;">
-                <!-- Options will be populated here -->
-            </select>
-        </div>
-    `;
+    const popupContentHtml = `<p>累计 ${todoChats.length} 长度的待总结文本，是否执行分步总结？</p>`;
+    // 移除了模板选择相关的HTML和逻辑
 
-    const $selector = $(popupContent.querySelector('#two_step_summary_template_selector'));
-    $selector.empty();
+    const popupId = 'stepwiseSummaryConfirm';
+    const confirmResult = await newPopupConfirm(
+        popupContentHtml,
+        "取消",
+        "执行总结",
+        popupId,
+        "暂不提醒"
+    );
 
-    if (typeof profile_prompts !== 'undefined' && profile_prompts !== null) {
-        Object.entries(profile_prompts).forEach(([key, prompt]) => {
-            let prefix = '';
-            if (prompt.type === 'third_party') prefix = '**第三方** ';
+    console.log('newPopupConfirm result for stepwise summary:', confirmResult);
 
-            $selector.append(
-                $('<option></option>')
-                    .val(key)
-                    .text(prefix + (prompt.name || key))
-            );
-        });
+    // confirmResult can be:
+    // true: User clicked "Execute" OR user clicked "Don't Remind" (which implies execution)
+    // false: User clicked "Cancel"
+    // 'dont_remind_active': Popup was suppressed because "Don't Remind" was previously selected.
 
-        if (Object.keys(profile_prompts).length > 0) {
-            // 优先使用上次选择的模板，其次是 'rebuild_base'，最后是列表中的第一个
-            const defaultKey = USER.tableBaseSetting?.lastSelectedTemplate || (profile_prompts['rebuild_base'] ? 'rebuild_base' : Object.keys(profile_prompts)[0]);
-            if (profile_prompts[defaultKey]) {
-                 $selector.val(defaultKey);
-            } else if (Object.keys(profile_prompts).length > 0) {
-                 // 如果上述都找不到，则选择第一个可用的
-                 $selector.val(Object.keys(profile_prompts)[0]);
-            }
-        }
-    } else {
-        console.warn('两步总结模板不可用，下拉菜单将为空或显示错误。');
-        $selector.append($('<option value="">模板加载失败</option>'));
-    }
+    // We proceed with execution if:
+    // 1. User explicitly confirmed (confirmResult === true). This covers first-time "Don't Remind" click.
+    // 2. Popup was suppressed (confirmResult === 'dont_remind_active'), meaning we should auto-proceed.
+    // We abort only if user explicitly cancelled (confirmResult === false).
 
-    const confirmationPopup = new EDITOR.Popup(popupContent, EDITOR.POPUP_TYPE.CONFIRM, '执行两步总结', {
-        okButton: "执行两步总结",
-        cancelButton: "取消"
-    });
-
-    await confirmationPopup.show();
-    console.log('confirmationPopup.result:', confirmationPopup.result);
-
-    if (!confirmationPopup.result) {
-        console.log('用户取消执行两步总结: ', `(${todoChats.length}) `, toBeExecuted);
+    if (confirmResult === false) {
+        console.log('用户取消执行分步总结: ', `(${todoChats.length}) `, toBeExecuted);
         MarkChatAsWaiting(currentPiece, swipeUid);
     } else {
-        const selectedTemplateKey = $selector.val();
-        USER.tableBaseSetting.lastSelectedTemplate = selectedTemplateKey; // 保存当前选择
-        console.log('用户选择的总结模板KEY:', selectedTemplateKey);
-        // const selectedTemplate = profile_prompts[selectedTemplateKey]; // 获取用户选择的总结模板
-        // console.log('用户选择的总结模板:', selectedTemplate);
+        // This block executes if confirmResult is true OR 'dont_remind_active'
+        if (confirmResult === 'dont_remind_active') {
+            console.log('分步总结弹窗已被禁止，自动执行。');
+        } else { // confirmResult === true
+            console.log('用户确认执行分步总结 (或首次选择了暂不提醒并确认)');
+        }
 
-        const r = await getPromptAndRebuildTable(selectedTemplateKey,'',true, undefined, todoChats);   // 执行两步总结
+        // 获取当前表格数据
+        const { piece: lastPiece } = BASE.getLastSheetsPiece();
+        if (!lastPiece) {
+            EDITOR.error('无法获取最新的表格数据以执行两步总结。');
+            MarkChatAsWaiting(currentPiece, swipeUid);
+            return;
+        }
+        const latestTables = BASE.hashSheetsToSheets(lastPiece.hash_sheets).filter(sheet => sheet.enable);
+        const originText = '<表格内容>\n' + latestTables
+            .map((table, index) => table.getTableText(index, ['title', 'node', 'headers', 'rows']))
+            .join("\n");
 
-        console.log('执行两步总结结果:', r);
-        //改为rebuild后只检查是否成功
-        if(r ==='success') {
+        const oldTableStructure = sheetsToTables(latestTables);
+        const tableHeadersOnly = oldTableStructure.map((table, index) => ({
+            tableName: table.tableName || `Table ${index + 1}`,
+            headers: table.columns || []
+        }));
+        const tableHeadersJson = JSON.stringify(tableHeadersOnly);
+        
+        const useMainApiForStepByStep = USER.tableBaseSetting.step_by_step_use_main_api === undefined ? true : USER.tableBaseSetting.step_by_step_use_main_api;
+
+        // 调用增量更新函数，并传递 isStepByStepSummary 标志
+        const r = await executeIncrementalUpdateFromSummary(
+            todoChats,
+            originText,
+            tableHeadersJson,
+            latestTables,
+            useMainApiForStepByStep, // API choice for step-by-step
+            USER.tableBaseSetting.bool_silent_refresh, // isSilentUpdate
+            true // isStepByStepSummary flag
+        );
+
+        console.log('执行分步总结（增量更新）结果:', r);
+        if (r === 'success') {
             toBeExecuted.forEach(chat => {
                 const chatSwipeUid = getSwipeUid(chat);
                 chat.two_step_links[chatSwipeUid].push(swipeUid);   // 标记已执行的两步总结
             });
             toBeExecuted = [];
+        } else if (r === 'suspended' || r === 'error' || !r) {
+            console.log('执行增量两步总结失败或取消: ', `(${todoChats.length}) `, toBeExecuted);
+            MarkChatAsWaiting(currentPiece, swipeUid);
         }
-
-
+        // Removed old rebuild logic and result handling as it's now incremental
         // if (!r || r === '' || r === 'error') {
         //     console.log('执行两步总结失败: ', `(${todoChats.length}) `, toBeExecuted);
         //     MarkChatAsWaiting(currentPiece, swipeUid);

--- a/scripts/settings/devConsole.js
+++ b/scripts/settings/devConsole.js
@@ -14,18 +14,20 @@ function updateTableDebugLog(type, message, detail = "", timeout, stack) {
     };
     switch (type) {
         case 'info':
-            toastr.info(message, detail, timeout);
+            toastr.info(message, detail, { timeOut: timeout });
             break;
         case 'success':
-            toastr.success(message, detail, timeout);
+            toastr.success(message, detail, { timeOut: timeout });
             break;
         case 'warning':
             console.warn(message, detail);
-            toastr.warning(message, detail, timeout);
+            toastr.warning(message, detail, { timeOut: timeout });
             break;
         case 'error':
             console.error(message, detail);
-            toastr.error(message, detail, timeout);
+            // Assuming 'detail' is intended as the title for toastr.
+            // If detail is an empty string, toastr might not show a title, which is fine.
+            toastr.error(message, detail, { timeOut: timeout });
             if (isPopupOpening) break;
             if (USER.tableBaseSetting.tableDebugModeAble) {
                 setTimeout(() => {
@@ -128,7 +130,17 @@ export const consoleMessageToEditor = {
     info: (message, detail, timeout) => updateTableDebugLog('info', message, detail, timeout),
     success: (message, detail, timeout) => updateTableDebugLog('success', message, detail, timeout),
     warning: (message, detail, timeout) => updateTableDebugLog('warning', message, detail, timeout),
-    error: (message, detail, error, timeout) => updateTableDebugLog('error', message+error?.name, detail, timeout, error?.stack),
+    // 如果 error 参数是一个真正的 Error 对象，则可以附加 error.message 或 error.name。
+    // 但如果调用者只传递了字符串，那么 error 参数会是 undefined。
+    // 假设主要的错误信息已经在 message 或 detail 中。
+    // 如果需要显示堆栈，则 error 参数应该是 Error 对象。
+    error: (message, detail, errorObj, timeout) => {
+        let fullMessage = message;
+        // 如果 detail 存在，可以考虑如何合并它，或者假设它已包含在 message 中。
+        // For now, let's assume 'message' contains the primary string and 'detail' is secondary.
+        // The 'errorObj' is specifically for stack trace.
+        updateTableDebugLog('error', fullMessage, detail, timeout, errorObj?.stack);
+    },
     clear: () => updateTableDebugLog('clear', ''),
 }
 

--- a/scripts/settings/standaloneAPI.js
+++ b/scripts/settings/standaloneAPI.js
@@ -256,8 +256,16 @@ export async function testApiConnection(apiUrl, apiKeys, modelName) {
                 throw new Error('Invalid or empty response received.');
             }
         } catch (error) {
-            console.error(`API Key index ${i} test failed:`, error);
-            results.push({ keyIndex: i, success: false, error: error.message || 'Unknown error' });
+            console.error(`API Key index ${i} test failed (raw error object):`, error); // Log the raw error object
+            let errorMessage = 'Unknown error';
+            if (error instanceof Error) {
+                errorMessage = error.message;
+            } else if (typeof error === 'string') {
+                errorMessage = error;
+            } else if (error && typeof error.toString === 'function') {
+                errorMessage = error.toString();
+            }
+            results.push({ keyIndex: i, success: false, error: errorMessage });
         }
     }
     return results;
@@ -350,9 +358,10 @@ export async function handleCustomAPIRequest(systemPrompt, userPrompt) {
         return 'suspended';
     }
 
-    EDITOR.error(`所有 ${attempts} 次尝试均失败。最后错误: ${lastError?.message || '未知错误'}`);
+    const errorMessage = `所有 ${attempts} 次尝试均失败。最后错误: ${lastError?.message || '未知错误'}`;
+    EDITOR.error(errorMessage);
     console.error('所有API调用尝试均失败。', lastError);
-    return; // 返回错误信息
+    return `错误: ${errorMessage}`; // 返回一个明确的错误字符串
 
     // // 公共请求配置 (Commented out original code remains unchanged)
     // const requestConfig = {

--- a/scripts/settings/userExtensionSetting.js
+++ b/scripts/settings/userExtensionSetting.js
@@ -417,6 +417,10 @@ function InitBinging() {
         $('#step_by_step_threshold_value').text(value);
         USER.tableBaseSetting.step_by_step_threshold = Number(value);
     });
+    // 分步总结破限词
+    $('#step_by_step_breaking_limit_words').on('input', function() {
+        USER.tableBaseSetting.step_by_step_breaking_limit_words = $(this).val();
+    });
     // 清理聊天记录楼层
     $('#clear_up_stairs').on('input', function() {
         const value = $(this).val();
@@ -501,6 +505,10 @@ export function renderSetting() {
     $('#custom_temperature_value').text(USER.tableBaseSetting.custom_temperature);
     $('#step_by_step_threshold').val(USER.tableBaseSetting.step_by_step_threshold);
     $('#step_by_step_threshold_value').text(USER.tableBaseSetting.step_by_step_threshold);
+    // Load step-by-step breaking limit words
+    $('#step_by_step_breaking_limit_words').val(USER.tableBaseSetting.step_by_step_breaking_limit_words || '');
+    // 分步填表读取的上下文层数
+    $('#separateReadContextLayers').val(USER.tableBaseSetting.separateReadContextLayers);
     refreshRebuildTemplate()
 
     // private data

--- a/services/llmApi.js
+++ b/services/llmApi.js
@@ -1,6 +1,6 @@
 import {USER} from '../core/manager.js';
 // @ts-ignore
-//import { ChatCompletionService } from '/scripts/custom-request.js';
+import { ChatCompletionService } from '/scripts/custom-request.js';
 //先注释掉防止无法启动
 
 export class LLMApiService {
@@ -35,6 +35,20 @@ export class LLMApiService {
         // 如果配置了代理地址，则使用 SillyTavern 的内部路由
         if (USER.IMPORTANT_USER_PRIVACY_DATA.table_proxy_address) {
             console.log("检测到代理配置，将使用 SillyTavern 内部路由");
+            // 检查 ChatCompletionService 是否实际可用 (基于当前代码被注释的情况)
+            // const chatCompletionServiceAvailable = false; // 因为相关代码被注释了
+            // if (!chatCompletionServiceAvailable) {
+            // const errorMessage = "代理功能当前未启用或配置不完整 (ChatCompletionService is commented out). 请取消代理设置或联系开发者。";
+            // console.error(errorMessage);
+            // throw new Error(errorMessage);
+            // }
+            // 假设 ChatCompletionService 总是可用的，如果导入成功的话。
+            // 如果 custom-request.js 不存在或 ChatCompletionService 未导出，则会在启动时或首次使用时抛出更早的错误。
+            if (typeof ChatCompletionService === 'undefined' || !ChatCompletionService?.processRequest) {
+                const errorMessage = "代理服务 (ChatCompletionService) 未正确加载。请检查 '/scripts/custom-request.js' 文件是否存在且正确导出了 ChatCompletionService。";
+                console.error(errorMessage);
+                throw new Error(errorMessage);
+            }
             try {
                 const requestData = {
                     stream: this.config.stream,
@@ -52,8 +66,7 @@ export class LLMApiService {
                     if (!streamCallback || typeof streamCallback !== 'function') {
                         throw new Error("流式模式下必须提供有效的streamCallback函数");
                     }
-                    const streamGenerator = '' //临时注释用
-                    //const streamGenerator = await ChatCompletionService.processRequest(requestData, {}, false); // extractData = false for stream
+                    const streamGenerator = await ChatCompletionService.processRequest(requestData, {}, false); // extractData = false for stream
                     let fullResponse = '';
                     for await (const chunk of streamGenerator()) {
                         if (chunk.text) {
@@ -63,8 +76,7 @@ export class LLMApiService {
                     }
                     return this.#cleanResponse(fullResponse);
                 } else {
-                    const responseData = '' //临时注释用
-                    //const responseData = await ChatCompletionService.processRequest(requestData, {}, true); // extractData = true for non-stream
+                    const responseData = await ChatCompletionService.processRequest(requestData, {}, true); // extractData = true for non-stream
                     if (!responseData || !responseData.content) {
                         throw new Error("通过内部路由获取响应失败或响应内容为空");
                     }
@@ -234,8 +246,7 @@ export class LLMApiService {
                     proxy_password: USER.IMPORTANT_USER_PRIVACY_DATA.table_proxy_key || null,
                 };
                 // 使用 processRequest 进行非流式请求测试
-                const responseData = '' //临时注释用
-                //const responseData = await ChatCompletionService.processRequest(requestData, {}, true);
+                const responseData = await ChatCompletionService.processRequest(requestData, {}, true);
                 if (!responseData || !responseData.content) {
                     throw new Error("通过内部路由测试连接失败或响应内容为空");
                 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
         "moduleResolution": "node",
         "esModuleInterop": true,
         "outDir": "./dist",
-        "strict": true
+        "strict": true,
+        "allowJs": true
     },
-    "include": ["**/*.ts"]
+    "include": ["**/*.js", "**/*.ts"]
 }


### PR DESCRIPTION
1.修改了分步总结的逻辑，使其独立于表格整理，使用普通填表的预设加上自己设定的破限词进行填表，运行逻辑改为和普通填表一致，不再需要单独的表格预设。
2.增加了分步总结确认框暂时隐藏按钮，选取后默认选择是直到刷新网页。